### PR TITLE
Initial support for MPEG-DASH

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -9,7 +9,7 @@ from xbmcgui import ListItem
 from xbmcplugin import (addDirectoryItem, endOfDirectory, setResolvedUrl,
     setContent)
 
-from resources.lib import http, settings
+from resources.lib import http, kodi, settings
 from resources.lib.helpers import maybe_json, calc_aspect, json_date_to_info
 
 plugin = routing.Plugin()
@@ -145,7 +145,18 @@ def show_live():
                     extra = ' (Translated %i)' % id if id > 1 else ' (Translated)'
                 item = ListItem(conference.name + ': ' + room.display + extra)
                 item.setProperty('IsPlayable', 'true')
+                if stream.type == 'dash':
+                    dashproperty = 'inputstream'
+                    if kodi.major_version() < 19:
+                        dashproperty += 'addon'
+                    item.setProperty(dashproperty, 'inputstream.adaptive')
+                    item.setProperty('inputstream.adaptive.manifest_type', 'mpd')
+
                 addDirectoryItem(plugin.handle, stream.url, item, False)
+
+                # MPEG-DASH includes all translated streams
+                if stream.type == 'dash':
+                    break
 
     endOfDirectory(plugin.handle)
 

--- a/addon.py
+++ b/addon.py
@@ -118,6 +118,7 @@ def resolve_event(event, quality=None, format=None):
 def show_live():
     quality = settings.get_quality(plugin)
     format = settings.get_format(plugin)
+    prefer_dash = settings.prefer_dash(plugin)
 
     data = None
     try:
@@ -131,7 +132,7 @@ def show_live():
 
     for conference in data.conferences:
         for room in conference.rooms:
-            want = room.streams_sorted(quality, format)
+            want = room.streams_sorted(quality, format, prefer_dash)
 
             # Assumption: want now starts with the "best" alternative,
             # followed by an arbitrary number of translations, after which

--- a/resources/data/stream_v2.json
+++ b/resources/data/stream_v2.json
@@ -487,5 +487,88 @@
                 ]
             }
         ]
+    },
+    {
+        "conference": "DASHconf",
+        "slug": "dashconf",
+        "author": "Rainbow Dash",
+        "description": "Sample for DASH-only stream",
+        "keywords": "",
+        "schedule": null,
+        "startsAt": "2020-01-22T00:00:00+0000",
+        "endsAt": "2020-01-22T19:00:00+0000",
+        "isCurrentlyStreaming": true,
+        "groups": [
+            {
+                "group": "Lecture Rooms",
+                "rooms": [
+                    {
+                        "slug": "S1",
+                        "schedulename": "S1",
+                        "thumb": "https://cdn.c3voc.de/thumbnail/s1/thumb.jpeg",
+                        "link": "https://streaming.media.ccc.de/dashconf/S1",
+                        "display": "S1",
+                        "stream": "s1",
+                        "streams": [
+                            {
+                                "slug": "dash-native",
+                                "display": "S1",
+                                "type": "dash",
+                                "isTranslated": false,
+                                "videoSize": null,
+                                "urls": {
+                                    "dash": {
+                                        "display": "DASH, baby",
+                                        "tech": "Adaptive multi-format-multi-bitrate-Stream to rule the World!!1elf",
+                                        "url": "https://dash.akamaized.net/dash264/TestCases/10a/1/iis_forest_short_poem_multi_lang_480p_single_adapt_aaclc_sidx.mpd"
+                                    }
+                                }
+                            },
+                            {
+                                "slug": "audio-native",
+                                "display": "S1 Audio",
+                                "type": "audio",
+                                "isTranslated": false,
+                                "videoSize": null,
+                                "urls": {
+                                    "mp3": {
+                                        "display": "MP3",
+                                        "tech": "MP3-Audio, 96 kBit/s",
+                                        "url": "https://cdn.c3voc.de/s1_native.mp3"
+                                    },
+                                    "opus": {
+                                        "display": "Opus",
+                                        "tech": "Opus-Audio, 64 kBit/s",
+                                        "url": "https://cdn.c3voc.de/s1_native.opus"
+                                    }
+                                }
+                            },
+                            {
+                                "slug": "slides-native",
+                                "display": "S1 Slides",
+                                "type": "slides",
+                                "isTranslated": false,
+                                "videoSize": [
+                                    1920,
+                                    1080
+                                ],
+                                "urls": {
+                                    "webm": {
+                                        "display": "WebM",
+                                        "tech": "1024x576, VP8+Vorbis in WebM, 400 kBit/s",
+                                        "url": "https://cdn.c3voc.de/s1_native_slides.webm"
+                                    },
+                                    "hls": {
+                                        "display": "HLS",
+                                        "tech": "1024x576, h264+AAC im MPEG-TS-Container via HTTP, 400 kBit/s",
+                                        "url": "https://cdn.c3voc.de/s1_native_slides.m3u8"
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
     }
 ]

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -1,16 +1,12 @@
 # Kodi language file
-# Addon Name: media.ccc.de
 # Addon id: plugin.video.media-ccc-de
-# Addon version: 0.1
 # Addon Provider: Tobias Gruetzmacher
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC-Addons\n"
-"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: 2016-12-27 13:07+0000\n"
-"PO-Revision-Date: 2017-04-03 19:55+0200\n"
+"PO-Revision-Date: 2020-12-23 12:00+0200\n"
 "Last-Translator: Tobias Gruetzmacher <tobias-kodi@23.gs>\n"
-"Language-Team: LANGUAGE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -52,3 +48,8 @@ msgstr "Bevorzuge MPEG (hardware-beschleunigt)"
 msgctxt "#30112"
 msgid "Prefer WEBM (libre)"
 msgstr "Bevorzuge WEBM (libre)"
+
+msgctxt "#30120"
+msgid "Prefer MPEG-DASH for live streams"
+msgstr "Bevorzuge MPEG-DASH für Live-Streams"
+

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -1,16 +1,12 @@
 # Kodi language file
-# Addon Name: media.ccc.de
 # Addon id: plugin.video.media-ccc-de
-# Addon version: 0.1
 # Addon Provider: Tobias Gruetzmacher
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC-Addons\n"
-"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
 "POT-Creation-Date: 2016-12-27 13:07+0000\n"
-"PO-Revision-Date: 2017-04-03 19:55+0200\n"
+"PO-Revision-Date: 2020-12-23 12:00+0200\n"
 "Last-Translator: Tobias Gruetzmacher <tobias-kodi@23.gs>\n"
-"Language-Team: LANGUAGE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -58,5 +54,9 @@ msgstr ""
 
 msgctxt "#30112"
 msgid "Prefer WEBM (libre)"
+msgstr ""
+
+msgctxt "#30120"
+msgid "Prefer MPEG-DASH for live streams"
 msgstr ""
 

--- a/resources/lib/helpers.py
+++ b/resources/lib/helpers.py
@@ -2,9 +2,12 @@
 from __future__ import print_function, division, absolute_import
 
 
-def user_preference_sorter(prefer_quality, prefer_format):
+def user_preference_sorter(prefer_quality, prefer_format, prefer_dash=False):
     def do_sort(obj):
         prio = 0
+
+        if obj.type == 'dash':
+            prio += 50 if prefer_dash else -50
 
         if obj.format == prefer_format:
             prio += 20

--- a/resources/lib/kodi.py
+++ b/resources/lib/kodi.py
@@ -1,0 +1,14 @@
+# coding: utf-8
+from __future__ import print_function, division, absolute_import
+
+import re
+
+import xbmc
+
+
+def major_version():
+    verstr = xbmc.getInfoLabel('System.BuildVersion')
+    match = re.match(r'(\d+)\.', verstr)
+    if match:
+        return int(match.group(1))
+    return None

--- a/resources/lib/settings.py
+++ b/resources/lib/settings.py
@@ -21,3 +21,8 @@ def get_quality(plugin):
 
 def get_format(plugin):
     return FORMATS[get_setting_int(plugin, 'format')]
+
+
+def prefer_dash(plugin):
+    val = getSetting(plugin.handle, 'dash')
+    return val == 'true'

--- a/resources/lib/stream.py
+++ b/resources/lib/stream.py
@@ -32,14 +32,14 @@ class Room(object):
         self.slug = json["slug"]
         self.display = json["display"]
         if len(group) > 0:
-                self.display = group + ": " + self.display
+            self.display = group + ": " + self.display
 
-    def streams_sorted(self, quality, format, video=True):
+    def streams_sorted(self, quality, format, dash=False, video=True):
         print("Requested quality %s and format %s" % (quality, format))
-        typematch = "video" if video else "audio"
-        want = sorted(filter(lambda stream: stream.type == typematch,
+        typematch = ('video', 'dash') if video else ('audio', )
+        want = sorted(filter(lambda stream: stream.type in typematch,
                              self.streams),
-                      key=user_preference_sorter(quality, format))
+                      key=user_preference_sorter(quality, format, dash))
         return want
 
 
@@ -48,6 +48,7 @@ class Stream(object):
         self.format = name
         if self.format == 'hls':
             self.format = 'mp4'
+        self.hd = None
         if stream['videoSize'] is not None:
             self.hd = stream['videoSize'][0] >= 1280
         self.url = data['url']

--- a/resources/lib/test_stream.py
+++ b/resources/lib/test_stream.py
@@ -7,9 +7,10 @@ from .stream import Streams
 from .testdata import getfile
 
 
-DATA = list((quality, format, quality == 'hd')
+DATA = list((quality, format, quality == 'hd', dash)
     for quality in ('hd', 'sd')
-    for format in ('mp4', 'webm'))
+    for format in ('mp4', 'webm')
+    for dash in (True, False))
 
 
 def test_conferences():
@@ -27,43 +28,57 @@ def test_rooms():
     assert c.rooms[0].display == u"Für die Glupscher: Vortragssaal"
 
 
-@pytest.mark.parametrize('quality,format,hd', DATA)
-def test_streams(quality, format, hd):
+@pytest.mark.parametrize('quality,format,hd,dash', DATA)
+def test_streams(quality, format, hd, dash):
     s = Streams(SampleJson)
     c = s.conferences[0]
     r = c.rooms[0]
     assert len(r.streams) == 6
-    streams = r.streams_sorted(quality, format)
+    streams = r.streams_sorted(quality, format, dash)
     assert len(streams) == 4
     preferred = streams[0]
+    assert preferred.type == 'video'
     assert preferred.hd is hd
     assert preferred.format == format
     assert preferred.translated is False
 
 
-@pytest.mark.parametrize('quality,format,hd', DATA)
-def test_streams_multiple_translations(quality, format, hd):
+@pytest.mark.parametrize('quality,format,hd,prefer_dash', DATA)
+def test_streams_multiple_translations(quality, format, hd, prefer_dash):
     s = Streams(SampleJson)
     c = s.conferences[1]
     r = c.rooms[0]
     assert len(r.streams) == 25
-    streams = r.streams_sorted(quality, format)
-    assert len(streams) == 12
+    streams = r.streams_sorted(quality, format, prefer_dash)
+    assert len(streams) == 13
 
-    preferred = streams[0]
-    assert preferred.hd is hd
-    assert preferred.format == format
-    assert preferred.translated is False
+    if prefer_dash:
+        dash = streams[0]
+        native = streams[1]
+        trans1 = streams[2]
+        trans2 = streams[3]
+    else:
+        native = streams[0]
+        trans1 = streams[1]
+        trans2 = streams[2]
+        dash = streams[-1]
 
-    trans1 = streams[1]
+    assert native.hd is hd
+    assert native.format == format
+    assert native.translated is False
+
     assert trans1.hd is hd
     assert trans1.format == format
     assert trans1.translated is True
 
-    trans2 = streams[2]
     assert trans2.hd is hd
     assert trans2.format == format
     assert trans2.translated is True
+
+    assert dash.type == 'dash'
+    assert dash.hd is None
+    assert dash.format == 'dash'
+    assert dash.translated is False
 
 
 SampleJson = getfile('stream_v2.json')

--- a/resources/lib/test_stream.py
+++ b/resources/lib/test_stream.py
@@ -15,9 +15,11 @@ DATA = list((quality, format, quality == 'hd', dash)
 
 def test_conferences():
     s = Streams(SampleJson)
-    assert len(s.conferences) == 2
+    assert len(s.conferences) == 3
     assert s.conferences[0].slug == "eh17"
     assert s.conferences[0].name == "Easterhegg 2017"
+    assert s.conferences[2].slug == "dashconf"
+    assert s.conferences[2].name == "DASHconf"
 
 
 def test_rooms():
@@ -79,6 +81,21 @@ def test_streams_multiple_translations(quality, format, hd, prefer_dash):
     assert dash.hd is None
     assert dash.format == 'dash'
     assert dash.translated is False
+
+
+@pytest.mark.parametrize('quality,format,hd,dash', DATA)
+def test_dash_only(quality, format, hd, dash):
+    s = Streams(SampleJson)
+    c = s.conferences[2]
+    r = c.rooms[0]
+    assert len(r.streams) == 5
+    streams = r.streams_sorted(quality, format, dash)
+    assert len(streams) == 1
+    preferred = streams[0]
+    assert preferred.type == 'dash'
+    assert preferred.hd is None
+    assert preferred.format == 'dash'
+    assert preferred.translated is False
 
 
 SampleJson = getfile('stream_v2.json')

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -2,4 +2,5 @@
 <settings>
 	<setting id="quality" type="enum" label="30100" lvalues="30101|30102" default="0"/>
 	<setting id="format" type="enum" label="30110" lvalues="30111|30112" default="0"/>
+	<setting id="dash" type="bool" label="30120" default="false"/>
 </settings>


### PR DESCRIPTION
This fixes #23 - unfortunately, this is only tested very lightly (with a local web server and the test data from this repository), since I didn't find enough round tuits this year to do more work on it (and actually test against live conferences).

Additionally, this this pretty barebones, I really should add some warnings/errors if `inputstream.adaptive` isn't available, but I don't know how much time I'll have the coming days, so this has to do for now...